### PR TITLE
Set hero to full width instead of full viewport

### DIFF
--- a/client/src/components/pages/home/hero.tsx
+++ b/client/src/components/pages/home/hero.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from "react-intl";
 
 const Hero = () => {
   return (
-    <div className="hero flex flex-col md:items-start md:justify-start w-full sm:w-screen pl-3 pr-3  pb-[70px]  md:pt-[200px] md:pb-[144px] md:pl-[64px] gap-[24px]">
+    <div className="hero flex flex-col md:items-start md:justify-start w-full w-full pl-3 pr-3  pb-[70px]  md:pt-[200px] md:pb-[144px] md:pl-[64px] gap-[24px]">
       <img src={logo} className="w-2xl lg:w-5xl" alt="Logo" />
       <h2 className="text-white text-2xl md:text-3xl lg:text-5xl w-full font-bold">
         <FormattedMessage


### PR DESCRIPTION
## Changes
Sets hero component width to full instead of viewport. This prevents the hero component from expanding further than the rest of the page.

## Before
<img width="1512" alt="Screenshot 2025-06-02 at 8 14 47 PM" src="https://github.com/user-attachments/assets/a3c4a6e4-317c-437d-acb7-087abe84918d" />

## After
<img width="1512" alt="Screenshot 2025-06-02 at 8 15 18 PM" src="https://github.com/user-attachments/assets/7d90d3fc-c35b-443c-8cb3-148a1e72a49c" />
