### PR TITLE
Fallback to english for missing translations

### DIFF
--- a/client/src/components/pages/database/license-type.tsx
+++ b/client/src/components/pages/database/license-type.tsx
@@ -7,61 +7,51 @@ const LicenseType = () => {
       <h2 className="font-bold text-[36px] m-0">
         <FormattedMessage
           id="database-page.license-type.header2"
-          defaultMessage="What does each type of license mean?"
         />
       </h2>
       <p className="mt-[8px] mb-[32px] font-normal text-[16px]">
         <FormattedMessage
           id="database-page.license-type.header2-paragraph"
-          defaultMessage="Boston has several different types of licenses from a variety of different laws and statutes, which can lead to some confusion when applying for a license. These licenses can range from those that apply city-wide to licenses for specific areas of Boston. Below are some basic definitions of each license type to aid you in your search."
         />
       </p>
       <h3 className="font-medium text-[32px]">
         <FormattedMessage
           id="database-page.license-type.transferable-header2"
-          defaultMessage="Transferable Licenses"
         />
       </h3>
       <p className="mt-[8px] mb-[32px] font-normal text-[16px]">
         <FormattedMessage
           id="database-page.license-type.transferable-paragraph"
-          defaultMessage="Licenses that have no restrictions preventing them from being transferred to another business and/or another part of the city of Boston. Most of the licenses in Boston are of this type, and all licenses issued before 2006 fall under this category."
         />
       </p>
       <h3 className="font-medium text-[32px]">
         <FormattedMessage
           id="database-page.license-type.nonTransferable-header3"
-          defaultMessage="Non-Transferable Licenses"
         />
       </h3>
       <p className="mt-[8px] mb-[16px] font-normal text-[16px]">
         <FormattedMessage
           id="database-page.license-type.nonTransferable-paragraph"
-          defaultMessage="Restrictions are placed on certain licenses, preventing them from being transferred outside of their legally designated area of Boston. These licenses can come in several different forms, most notably the licenses created under the 2024 law designating licenses to several zip codes."
         />
       </p>
       <h4 className="font-medium text-[24px]">
         <FormattedMessage
           id="database-page.license-type.law-header4"
-          defaultMessage="New 2024 Law"
         />
       </h4>
       <p className="mt-[8px] mb-[16px] font-normal text-[16px]">
         <FormattedMessage
           id="database-page.license-type.law-paragraph"
-          defaultMessage="In 2024, the city of Boston passed a new law to increase access to liquor licenses in several parts of Boston. Through this law, the city will issue 5 new on-premise liquor licenses to 13 of Boston's zip codes each year for the next 3 years."
         />
       </p>
       <h4 className="font-medium text-[24px]">
         <FormattedMessage
           id="database-page.license-type.specialAreas-header4"
-          defaultMessage="Special Areas of Boston"
         />
       </h4>
       <p className="mt-[8px] font-normal text-[16px]">
         <FormattedMessage
           id="database-page.license-type.specialAreas-paragraph"
-          defaultMessage="Another provision of the 2024 law was the creation of specialty licenses for Oak Square in Brighton. Several other laws in the past have also carved out licenses for specific areas of the city as well."
         />
       </p>
     </section>

--- a/client/src/i18n/I18n.tsx
+++ b/client/src/i18n/I18n.tsx
@@ -7,6 +7,19 @@ import {
 import { useState } from "react";
 import { LocaleContext } from "./locale-context";
 
+type Locale = keyof typeof supportedLocales;
+
+const getMessagesWithFallback = (locale: Locale) => {
+  const baseMessages = supportedLocales[defaultLocale].messages;
+  const localeMessages = supportedLocales[locale].messages;
+
+  if (locale === defaultLocale) {
+    return localeMessages;
+  } else {
+    return { ...baseMessages, ...localeMessages };
+  }
+}
+
 export default function I18n(props: React.PropsWithChildren) {
   const [locale, setLocale] =
     useState<keyof typeof supportedLocales>(getBestMatchLocale());
@@ -22,16 +35,4 @@ export default function I18n(props: React.PropsWithChildren) {
       </IntlProvider>
     </LocaleContext.Provider>
   );
-}
-
-const getMessagesWithFallback = (locale: Locale) => {
-  const baseMessages = supportedLocales[defaultLocale].messages;
-  const localeMessages = supportedLocales[locale].messages;
-
-  if (locale === defaultLocale) {
-    return localeMessages;
-  } else {
-    // Merge locale messages on top of base messages
-    return { ...baseMessages, ...localeMessages };
-  }
 }

--- a/client/src/i18n/I18n.tsx
+++ b/client/src/i18n/I18n.tsx
@@ -16,10 +16,22 @@ export default function I18n(props: React.PropsWithChildren) {
       <IntlProvider
         locale={locale}
         defaultLocale={defaultLocale}
-        messages={supportedLocales[locale].messages}
+        messages={getMessagesWithFallback(locale)}
       >
         {props.children}
       </IntlProvider>
     </LocaleContext.Provider>
   );
+}
+
+const getMessagesWithFallback = (locale: Locale) => {
+  const baseMessages = supportedLocales[defaultLocale].messages;
+  const localeMessages = supportedLocales[locale].messages;
+
+  if (locale === defaultLocale) {
+    return localeMessages;
+  } else {
+    // Merge locale messages on top of base messages
+    return { ...baseMessages, ...localeMessages };
+  }
 }


### PR DESCRIPTION
Defining english strings in two places creates opportunities for those strings to fall out of sync.
This change
- Creates a function to use english translations as a fallback for any translated message.
- Removes `defaultMessage` props from `FromattedMessage` components.