### PR TITLE
Update data interface filtering options

### DIFF
--- a/client/src/services/data-interface/data-interface.test.ts
+++ b/client/src/services/data-interface/data-interface.test.ts
@@ -4,40 +4,66 @@ import mockLicensesJson from "./mockData.json";
 import { BusinessLicense } from "./data-interface";
 
 describe("Testing the data access interface", () => {
-  test("getNumOfLicenses returns the proper number of licenses in a given zip code", () => {
+  test("return number of all city-wide licenses (all zipcodes & all alcohol types)", () => {
     const mockData = mockLicensesJson as BusinessLicense[];
 
-    expect(getNumOfLicenses(mockData, "02122")).toBe(2);
-    expect(getNumOfLicenses(mockData, "02130")).toBe(5);
-    expect(getNumOfLicenses(mockData, "02210")).toBe(1);
-    expect(getNumOfLicenses(mockData, "02128")).toBe(12);
-    expect(getNumOfLicenses(mockData, "02134")).toBe(1);
+    expect(getNumOfLicenses(mockData)).toBe(47);
   });
 
-  test("getNumOfLicenses returns proper number of licenses by zip code for certain alcohol type", () => {
+  test("returns the number of licenses by zip code for all alcohol types", () => {
+    const mockData = mockLicensesJson as BusinessLicense[];
+
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02122" })).toBe(2);
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02130" })).toBe(5);
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02210" })).toBe(1);
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02128" })).toBe(12);
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02134" })).toBe(1);
+  });
+
+  test("returns number of licenses by alcohol type for all zip codes", () => {
+    const mockData = mockLicensesJson as BusinessLicense[];
+
+    expect(
+      getNumOfLicenses(mockData, {
+        filterByAlcoholType: "Wines and Malt Beverages",
+      })
+    ).toBe(12);
+    expect(
+      getNumOfLicenses(mockData, {
+        filterByAlcoholType: "All Alcoholic Beverages",
+      })
+    ).toBe(35);
+  });
+
+  test("returns number of licenses by both zip code & alcohol type", () => {
     const mockData = mockLicensesJson as BusinessLicense[];
     expect(
-      getNumOfLicenses(mockData, "02122", {
+      getNumOfLicenses(mockData, {
+        filterByZipcode: "02122",
         filterByAlcoholType: "Wines and Malt Beverages",
       })
     ).toBe(2);
     expect(
-      getNumOfLicenses(mockData, "02130", {
+      getNumOfLicenses(mockData, {
+        filterByZipcode: "02130",
         filterByAlcoholType: "All Alcoholic Beverages",
       })
     ).toBe(2);
     expect(
-      getNumOfLicenses(mockData, "02130", {
+      getNumOfLicenses(mockData, {
+        filterByZipcode: "02130",
         filterByAlcoholType: "Wines and Malt Beverages",
       })
     ).toBe(3);
     expect(
-      getNumOfLicenses(mockData, "02128", {
+      getNumOfLicenses(mockData, {
+        filterByZipcode: "02128",
         filterByAlcoholType: "Wines and Malt Beverages",
       })
     ).toBe(3);
     expect(
-      getNumOfLicenses(mockData, "02128", {
+      getNumOfLicenses(mockData, {
+        filterByZipcode: "02128",
         filterByAlcoholType: "All Alcoholic Beverages",
       })
     ).toBe(9);

--- a/client/src/services/data-interface/data-interface.ts
+++ b/client/src/services/data-interface/data-interface.ts
@@ -189,7 +189,7 @@ export default function getNumOfLicenses(
     }
   }
 
-  if (options?.filterByAlcoholType && options.filterByZipcode) {
+  if (options?.filterByAlcoholType && options?.filterByZipcode) {
     const licenseByZipAndType = data.filter(
       (license) =>
         license.zipcode === options.filterByZipcode &&

--- a/client/src/services/data-interface/data-interface.ts
+++ b/client/src/services/data-interface/data-interface.ts
@@ -166,12 +166,12 @@ function validateBusinessLicense(license: unknown): ValidationResult {
 
 export default function getNumOfLicenses(
   data: BusinessLicense[],
-  filterByZipcode: BostonZipCode,
   options?: {
-    filterByAlcoholType: string;
+    filterByZipcode?: BostonZipCode;
+    filterByAlcoholType?: string;
   }
 ): number {
-  if (!isBostonZipCode(filterByZipcode)) {
+  if (options?.filterByZipcode && !isBostonZipCode(options?.filterByZipcode)) {
     throw new Error(
       "You must enter a zipcode within the City of Boston. See https://data.boston.gov/dataset/zip-codes/resource/a9b44fec-3a21-42ac-a919-06ec4ac20ab8"
     );
@@ -189,19 +189,27 @@ export default function getNumOfLicenses(
     }
   }
 
-  if (options?.filterByAlcoholType) {
+  if (options?.filterByAlcoholType && options.filterByZipcode) {
     const licenseByZipAndType = data.filter(
       (license) =>
-        license.zipcode === filterByZipcode &&
+        license.zipcode === options.filterByZipcode &&
         license.alcohol_type === options.filterByAlcoholType
     );
 
     return licenseByZipAndType.length;
-  } else {
+  } else if (options?.filterByZipcode) {
     const licensesByZip = data.filter(
-      (license) => license.zipcode === filterByZipcode
+      (license) => license.zipcode === options.filterByZipcode
     );
 
     return licensesByZip.length;
+  } else if (options?.filterByAlcoholType) {
+    const licensesByType = data.filter(
+      (license) => license.alcohol_type === options.filterByAlcoholType
+    );
+
+    return licensesByType.length;
+  } else {
+    return data.length;
   }
 }


### PR DESCRIPTION
Prior - Only filtering by:
1. zipcode 
2. zipcode & alcohol type

Update allows the following filter options:
1. get licenses for all zipcodes & alcohol types
2. by zipcode
3. by alcohol type
4. by zipcode & alcohol types

Added tests for new filtering options.