### PR TITLE
Remove base url

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,7 +9,6 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/boston-liquor-license-tracker/',
   plugins: [
     // Please make sure that '@tanstack/router-plugin' is passed before '@vitejs/plugin-react'
     TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),


### PR DESCRIPTION
The base url was needed when we were using the github pages url.
Now that we are moving over to license2suceed.org, we need to remove the base.