### PR TITLE
Data Interface Update

### DIFF
--- a/client/src/services/data-interface/data-interface.test.ts
+++ b/client/src/services/data-interface/data-interface.test.ts
@@ -2,22 +2,39 @@ import { expect, test, describe } from "vitest";
 import getNumOfLicenses from "./data-interface";
 import mockLicensesJson from "./mockData.json";
 import { BusinessLicense } from "./data-interface";
+const MAX_LICENSES_AVAILABLE = 165;
+const MAX_BEER_WINE_LICENSES = 78;
+const MAX_ALL_ALC_LICENSES = 117;
+
+const MAX_AVAILABLE_PER_ZIP = 15;
+const MAX_ALL_ALC_PER_ZIP = 9;
+const MAX_BEER_WINE_PER_ZIP = 6;
 
 describe("Testing the data access interface", () => {
   test("return number of all city-wide licenses (all zipcodes & all alcohol types)", () => {
     const mockData = mockLicensesJson as BusinessLicense[];
-
-    expect(getNumOfLicenses(mockData)).toBe(47);
+    const expected = MAX_LICENSES_AVAILABLE - 47;
+    expect(getNumOfLicenses(mockData)).toBe(expected);
   });
 
   test("returns the number of licenses by zip code for all alcohol types", () => {
     const mockData = mockLicensesJson as BusinessLicense[];
 
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02122" })).toBe(2);
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02130" })).toBe(5);
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02210" })).toBe(1);
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02128" })).toBe(12);
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02134" })).toBe(1);
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02122" })).toBe(
+      MAX_AVAILABLE_PER_ZIP - 2
+    );
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02130" })).toBe(
+      MAX_AVAILABLE_PER_ZIP - 5
+    );
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02210" })).toBe(
+      MAX_AVAILABLE_PER_ZIP - 1
+    );
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02128" })).toBe(
+      MAX_AVAILABLE_PER_ZIP - 12
+    );
+    expect(getNumOfLicenses(mockData, { filterByZipcode: "02134" })).toBe(
+      MAX_AVAILABLE_PER_ZIP - 1
+    );
   });
 
   test("returns number of licenses by alcohol type for all zip codes", () => {
@@ -27,12 +44,12 @@ describe("Testing the data access interface", () => {
       getNumOfLicenses(mockData, {
         filterByAlcoholType: "Wines and Malt Beverages",
       })
-    ).toBe(12);
+    ).toBe(MAX_BEER_WINE_LICENSES - 12);
     expect(
       getNumOfLicenses(mockData, {
         filterByAlcoholType: "All Alcoholic Beverages",
       })
-    ).toBe(35);
+    ).toBe(MAX_ALL_ALC_LICENSES - 35);
   });
 
   test("returns number of licenses by both zip code & alcohol type", () => {
@@ -42,30 +59,30 @@ describe("Testing the data access interface", () => {
         filterByZipcode: "02122",
         filterByAlcoholType: "Wines and Malt Beverages",
       })
-    ).toBe(2);
+    ).toBe(MAX_BEER_WINE_PER_ZIP - 2);
     expect(
       getNumOfLicenses(mockData, {
         filterByZipcode: "02130",
         filterByAlcoholType: "All Alcoholic Beverages",
       })
-    ).toBe(2);
+    ).toBe(MAX_ALL_ALC_PER_ZIP - 2);
     expect(
       getNumOfLicenses(mockData, {
         filterByZipcode: "02130",
         filterByAlcoholType: "Wines and Malt Beverages",
       })
-    ).toBe(3);
+    ).toBe(MAX_BEER_WINE_PER_ZIP - 3);
     expect(
       getNumOfLicenses(mockData, {
         filterByZipcode: "02128",
         filterByAlcoholType: "Wines and Malt Beverages",
       })
-    ).toBe(3);
+    ).toBe(MAX_BEER_WINE_PER_ZIP - 3);
     expect(
       getNumOfLicenses(mockData, {
         filterByZipcode: "02128",
         filterByAlcoholType: "All Alcoholic Beverages",
       })
-    ).toBe(9);
+    ).toBe(MAX_ALL_ALC_PER_ZIP - 9);
   });
 });

--- a/client/src/services/data-interface/data-interface.test.ts
+++ b/client/src/services/data-interface/data-interface.test.ts
@@ -2,7 +2,9 @@ import { expect, test, describe } from "vitest";
 import getNumOfLicenses from "./data-interface";
 import mockLicensesJson from "./mockData.json";
 import { BusinessLicense } from "./data-interface";
-const MAX_LICENSES_AVAILABLE = 165;
+
+// INFO on these constants in the data-interface.ts file
+const MAX_LICENSES_AVAILABLE = 195;
 const MAX_BEER_WINE_LICENSES = 78;
 const MAX_ALL_ALC_LICENSES = 117;
 

--- a/client/src/services/data-interface/data-interface.ts
+++ b/client/src/services/data-interface/data-interface.ts
@@ -1,3 +1,17 @@
+// The data interface relies on these constants below to calculate available licenses based off filtering options.
+
+// Does NOT include the 3 Oak Square all alcohol licenses,
+// the 15 non-transferable licenses for community spaces, including outdoor spaces, theaters with fewer than 750 seats, and non-profit organizations,
+// or the 12 transferable All Alcohol licenses
+
+const MAX_LICENSES_AVAILABLE = 165; // Total available remaining NON-TRANSFERABLE, ZIPCODE-RESTRICTED Licenses from the 2024 legislation
+const MAX_BEER_WINE_LICENSES = 78;
+const MAX_ALL_ALC_LICENSES = 117;
+
+const MAX_AVAILABLE_PER_ZIP = 15; // 5 licenses granted per year (3 All Alcohol, 2 Wines & Malt Liquor)
+const MAX_ALL_ALC_PER_ZIP = 9;
+const MAX_BEER_WINE_PER_ZIP = 6;
+
 export interface BusinessLicense {
   entity_number: string;
   business_name: string;
@@ -190,26 +204,40 @@ export default function getNumOfLicenses(
   }
 
   if (options?.filterByAlcoholType && options?.filterByZipcode) {
-    const licenseByZipAndType = data.filter(
+    const licensesByZipAndType = data.filter(
       (license) =>
         license.zipcode === options.filterByZipcode &&
         license.alcohol_type === options.filterByAlcoholType
     );
 
-    return licenseByZipAndType.length;
+    if (options.filterByAlcoholType === "All Alcoholic Beverages") {
+      return MAX_ALL_ALC_PER_ZIP - licensesByZipAndType.length;
+    } else if (options.filterByAlcoholType === "Wines and Malt Beverages") {
+      return MAX_BEER_WINE_PER_ZIP - licensesByZipAndType.length;
+    } else {
+      console.error("improper alcohol license type used");
+      return -1;
+    }
   } else if (options?.filterByZipcode) {
     const licensesByZip = data.filter(
       (license) => license.zipcode === options.filterByZipcode
     );
 
-    return licensesByZip.length;
+    return MAX_AVAILABLE_PER_ZIP - licensesByZip.length;
   } else if (options?.filterByAlcoholType) {
     const licensesByType = data.filter(
       (license) => license.alcohol_type === options.filterByAlcoholType
     );
 
-    return licensesByType.length;
+    if (options.filterByAlcoholType === "All Alcoholic Beverages") {
+      return MAX_ALL_ALC_LICENSES - licensesByType.length;
+    } else if (options.filterByAlcoholType === "Wines and Malt Beverages") {
+      return MAX_BEER_WINE_LICENSES - licensesByType.length;
+    } else {
+      console.error("improper alcohol license type used");
+      return -1;
+    }
   } else {
-    return data.length;
+    return MAX_LICENSES_AVAILABLE - data.length;
   }
 }

--- a/client/src/services/data-interface/data-interface.ts
+++ b/client/src/services/data-interface/data-interface.ts
@@ -4,11 +4,11 @@
 // the 15 non-transferable licenses for community spaces, including outdoor spaces, theaters with fewer than 750 seats, and non-profit organizations,
 // or the 12 transferable All Alcohol licenses
 
-const MAX_LICENSES_AVAILABLE = 165; // Total available remaining NON-TRANSFERABLE, ZIPCODE-RESTRICTED Licenses from the 2024 legislation
+const MAX_LICENSES_AVAILABLE = 195; // Total available remaining NON-TRANSFERABLE, ZIPCODE-RESTRICTED Licenses from the 2024 legislation
 const MAX_BEER_WINE_LICENSES = 78;
 const MAX_ALL_ALC_LICENSES = 117;
 
-const MAX_AVAILABLE_PER_ZIP = 15; // 5 licenses granted per year (3 All Alcohol, 2 Wines & Malt Liquor)
+const MAX_AVAILABLE_PER_ZIP = 15; // 5 licenses granted per year for 3 years (3 All Alcohol, 2 Wines & Malt Liquor)
 const MAX_ALL_ALC_PER_ZIP = 9;
 const MAX_BEER_WINE_PER_ZIP = 6;
 


### PR DESCRIPTION
**Issue Fixed**: Data Interface method previously gave counts for the licenses granted.

We want to display the licenses available from the total number of non-transferable, zipcode-restricted licenses:
- This required subtracting the count of granted licenses (based off filters) from the maximum available licenses.
- Tests updated accordingly