### PR TITLE
Audit next meeting date script

### DIFF
--- a/client/src/scripts/next-meeting-date.ts
+++ b/client/src/scripts/next-meeting-date.ts
@@ -35,7 +35,7 @@ async function scrapeNextMeetingDate(url: string): Promise<Date | null> {
     return nextMeetingDate;
   } catch (error) {
     console.log("Error scraping next meeting date:", error);
-    return null;
+    throw error; // Re-throw the error so further Github Actions steps are aborted
   }
 }
 

--- a/client/src/scripts/next-meeting-date.ts
+++ b/client/src/scripts/next-meeting-date.ts
@@ -39,17 +39,19 @@ async function scrapeNextMeetingDate(url: string): Promise<Date | null> {
   }
 }
 
-try {
-  const nextMeetingDate = await scrapeNextMeetingDate(
-    "https://www.boston.gov/departments/licensing-board/licensing-board-information-and-members"
-  );
-  if (nextMeetingDate) {
-    const meetingDateObject = {
-      nextMeetingDate: nextMeetingDate.toISOString(),
-    };
-    const meetingDateString = JSON.stringify(meetingDateObject);
-    writeFileSync("../data/next-meeting-date.json", meetingDateString);
-  }
-} catch (error) {
-  console.error("Error in next meeting date script execution:", error);
+const nextMeetingDate = await scrapeNextMeetingDate(
+  "https://www.boston.gov/departments/licensing-board/licensing-board-information-and-members"
+);
+if (
+  nextMeetingDate &&
+  nextMeetingDate instanceof Date &&
+  !isNaN(nextMeetingDate.getTime())
+) {
+  const meetingDateObject = {
+    nextMeetingDate: nextMeetingDate.toISOString(),
+  };
+  const meetingDateString = JSON.stringify(meetingDateObject);
+  writeFileSync("../data/next-meeting-date.json", meetingDateString);
+} else {
+  throw new Error("Failed to scrape a valid next meeting date.");
 }

--- a/client/src/scripts/next-meeting-date.ts
+++ b/client/src/scripts/next-meeting-date.ts
@@ -34,7 +34,7 @@ async function scrapeNextMeetingDate(url: string): Promise<Date | null> {
 
     return nextMeetingDate;
   } catch (error) {
-    console.log("Error scraping next meeting date:", error);
+    console.error("Error scraping next meeting date:", error);
     throw error; // Re-throw the error so further Github Actions steps are aborted
   }
 }
@@ -53,5 +53,6 @@ if (
   const meetingDateString = JSON.stringify(meetingDateObject);
   writeFileSync("../data/next-meeting-date.json", meetingDateString);
 } else {
+  console.error("Invalid next meeting date:", nextMeetingDate);
   throw new Error("Failed to scrape a valid next meeting date.");
 }


### PR DESCRIPTION
This PR makes two changes to the next meeting date scraping logic:

1. If the scraper encounters an error, the error catcher rethrows the error so that further Github Action steps are aborted and no commits are made against the code repository.
2. If the next meeting date is not a valid `Date` object, an error is thrown so that further Github Action steps are aborted and no commits are made against the code repository.

It is not practical to catch malformed JSON objects on the application end since Vite will throw an error on import that the application cannot catch. This isn't an issue we have to worry about since we create the object ourselves and write it using `JSON.stringify`, which is probably more robust than anything we can come up with.