### PR TITLE
Applicant pipeline fix

### DIFF
--- a/.github/workflows/liquor-license-applicant-pipeline.yml
+++ b/.github/workflows/liquor-license-applicant-pipeline.yml
@@ -12,7 +12,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  process-pdf:
+  check-pdf:
+    outputs:
+      pdf-found: ${{ steps.check.outputs.pdf-found }}
+      pdf-file: ${{ steps.check.outputs.pdf-file }}
+      voting-date: ${{ steps.check.outputs.voting-date }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -37,7 +41,7 @@ jobs:
         run: npx tsc -t es2022 -m nodenext --moduleResolution nodenext getVotingMinutes.ts
 
       - name: Run get voting minutes
-        id: generate
+        id: check
         working-directory: ./scripts
         run: |
           OUTPUT=$(node getVotingMinutes.js 2>&1 | tee /dev/stderr)
@@ -47,11 +51,40 @@ jobs:
             echo "Script failed : $(echo "$SEL_OUTPUT" | jq -r '.message')"
             exit 1 
           fi
+
           PDF_FILE=$(echo "$SEL_OUTPUT" | jq -r '.fileName')
           VOTING_DATE=$(echo "$SEL_OUTPUT" | jq -r '.pdfDate')
-          echo "pdf_file=$PDF_FILE" >> $GITHUB_OUTPUT
-          echo "voting_date=$VOTING_DATE" >> $GITHUB_OUTPUT
- 
+
+          # Exit early if no new PDF to process
+          if [ "$PDF_FILE" = "null" ] || [ "$VOTING_DATE" = "null" ]; then
+            echo "pdf-found=false" >> $GITHUB_OUTPUT
+          else
+            echo "pdf-found=true" >> $GITHUB_OUTPUT
+            echo "pdf-file=$PDF_FILE" >> $GITHUB_OUTPUT
+            echo "voting-date=$VOTING_DATE" >> $GITHUB_OUTPUT
+          fi
+    
+      - name: Upload voting PDF
+        uses: actions/upload-artifact@v4
+        if: steps.check.outputs.pdf-found == 'true'
+        with:
+          name: voting-pdf 
+          path: ./scripts/${{ steps.check.outputs.pdf-file }}
+          if-no-files-found: error
+          retention-days: 2
+    
+  
+  process-pdf:
+    needs: check-pdf 
+    if: needs.check-pdf.outputs.pdf-found == 'true'
+    runs-on: ubuntu-latest 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: "codeforboston/boston-liquor-license-tracker"
+          ref: "main"
+
       - name: Setup python 
         uses: actions/setup-python@v5
         with: 
@@ -61,10 +94,27 @@ jobs:
       - name: Install Python dependencies
         working-directory: ./scripts
         run: pip install -r requirements.txt
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: "npm"
+          cache-dependency-path: scripts/package-lock.json
+      
+      - name: Install dependencies
+        working-directory: ./scripts
+        run: npm ci 
+      
+      - name: Download voting pdf
+        uses: actions/download-artifact@v5
+        with: 
+          name: voting-pdf 
+          path: ./scripts
 
       - name: Run python script 
         working-directory: ./scripts
-        run: python3 extract_entity.py ${{ steps.generate.outputs.pdf_file}}
+        run: python3 extract_entity.py ${{ needs.check-pdf.outputs.pdf-file }}
       
       - name: Compile update processed date 
         working-directory: ./scripts
@@ -72,7 +122,7 @@ jobs:
 
       - name: Run update processed date 
         working-directory: ./scripts 
-        run: node updateLastProcessedDate.js ${{ steps.generate.outputs.voting_date}}
+        run: node updateLastProcessedDate.js ${{ needs.check-pdf.outputs.voting-date }}
 
       - name: Create pull request to merge in new next meeting date
         uses: peter-evans/create-pull-request@v7
@@ -85,7 +135,7 @@ jobs:
           branch: update-liquor-license-data
           delete-branch: true
           commit-message: "[SCRIPT] Update liquor license applicant data"
-          committer: Github Actions <hello@codeforboston.org>
-          author: Github Actions <hello@codeforboston.org>
+          committer: Github Actions <gopalakrishnanunni.a@northeastern.edu>
+          author: Github Actions <gopalakrishnanunni.a@northeastern.edu>
           add-paths: |
             data/*.json

--- a/.github/workflows/liquor-license-applicant-pipeline.yml
+++ b/.github/workflows/liquor-license-applicant-pipeline.yml
@@ -135,7 +135,7 @@ jobs:
           branch: update-liquor-license-data
           delete-branch: true
           commit-message: "[SCRIPT] Update liquor license applicant data"
-          committer: Github Actions <gopalakrishnanunni.a@northeastern.edu>
-          author: Github Actions <gopalakrishnanunni.a@northeastern.edu>
+          committer: Github Actions <hello@codeforboston.org>
+          author: Github Actions <hello@codeforboston.org>
           add-paths: |
             data/*.json

--- a/scripts/getVotingMinutes.ts
+++ b/scripts/getVotingMinutes.ts
@@ -4,6 +4,7 @@ import axios from 'axios'
 import fs from 'fs/promises';
 import path from 'path'
 import { fileURLToPath } from "url";
+import { maxHeaderSize } from 'http';
 
 interface EntityType{
    href: string | null, 
@@ -20,6 +21,17 @@ async function main(){
   const url = 'https://www.boston.gov/departments/licensing-board/licensing-board-information-and-members'
    try{
       const pdfDate = await getLatestDate(url)
+      if(!pdfDate){
+        const result = {
+           success: true,
+           pdfDate: null, 
+           fileName: null, 
+           message: 'No new date found to add entities - already up to date'
+        }
+        console.log("::JSON_OUTPUT::"+JSON.stringify(result))
+        return
+      }
+      
       const fileName = await downloadVotingMinutes(pdfDate, url)
       const result = {
          success : true, 
@@ -73,8 +85,6 @@ async function downloadVotingMinutes(pdfDate : Date, url: string) : Promise<stri
           const date = new Date(`${month} ${day}, ${year}`)
           console.log(`date checked is ${date}`)
           if(date.getTime() === pdfDate.getTime()){
-             console.log(`date matched is ${date}`)
-             console.log('url matched is ',$(e).attr("href") )
             entity['href'] = $(e).attr("href") ?? null
             entity['dateText'] = $(e).text() 
             entity['votingDate'] = date.toISOString()
@@ -91,9 +101,7 @@ async function downloadVotingMinutes(pdfDate : Date, url: string) : Promise<stri
     const pdfData = await axios.get(fullUrl, {
       responseType: 'arraybuffer'
     })
-    console.log('pdf data is ', pdfData.data)
     const fileName = entity["href"].split('/').pop()
-    console.log('file name is ', fileName)
     if(fileName){
       const filePath = path.join(__dirname, fileName)
       await fs.writeFile(filePath, pdfData.data)
@@ -114,7 +122,7 @@ async function downloadVotingMinutes(pdfDate : Date, url: string) : Promise<stri
  * If the latest processed date matches it, the script terminates early
  * to avoid redundant downloads.
  */
-async function getLatestDate(url: string) {
+async function getLatestDate(url: string): Promise<Date| null> {
    try {
     
     const currentDate = new Date();
@@ -144,18 +152,26 @@ async function getLatestDate(url: string) {
 
     // Only consider meetings that have already happened
     const pastDates = meetingDates.filter((date) => date <= currentDate)
-    const maxPastDate = new Date(Math.max(...pastDates.map(d => d.getTime())))
+    if (pastDates.length === 0) {
+      console.log("No past meeting dates found")
+      return null
+    }
     try{
       const lastProcessedDate = await getWrittenLatestDate()
-      if(lastProcessedDate.getTime() === maxPastDate.getTime()){
+      const unprocessedDates = pastDates.filter((date) => date > lastProcessedDate)
+
+      if (unprocessedDates.length === 0) {
         console.log("No new date found to add entities")
-        process.exit(0)
+        return null // Return null instead of process.exit(0)
       }
+      const nextDateToProcess = new Date(Math.min(...unprocessedDates.map(d => d.getTime())))
+      return nextDateToProcess
     } catch(err){
        console.log('Last processed date file is not found')
+       const maxPastDate = new Date(Math.max(...pastDates.map(date => date.getTime())))
+       return maxPastDate;
     }
 
-    return maxPastDate;
   } catch (error) {
     console.error("Error scraping next meeting date:", error);
     throw error; // Re-throw the error so further Github Actions steps are aborted


### PR DESCRIPTION
Previously, when no PDFs were found, the action was erroring out,  which wasn’t the expected behavior. To fix this, I split the action into two jobs: one to check if there are any new PDFs, and another to process them. If no PDFs are found in the first job, the second job won’t run. Also improved the logs when no new pdfs are found.

I think this makes for a much cleaner workflow run. I also updated some logic in getVotingMinutes.ts to restrict the search between currentDate and lastProcessedDate.

Feel free to suggest any improvements