### PR TITLE
Data Interface Update For New Chart

### DIFF
--- a/client/src/services/data-interface/data-interface.test.ts
+++ b/client/src/services/data-interface/data-interface.test.ts
@@ -2,6 +2,11 @@ import { expect, test, describe } from "vitest";
 import getNumOfLicenses from "./data-interface";
 import mockLicensesJson from "./mockData.json";
 import { BusinessLicense } from "./data-interface";
+import {
+  getAvailableLicensesByZipcode,
+  getZipcodesWithAvailableLicenses,
+  isEligibleBostonZipCode,
+} from "./data-interface";
 
 // INFO on these constants in the data-interface.ts file
 import {
@@ -10,82 +15,113 @@ import {
   MAX_ALL_ALC_LICENSES,
   MAX_AVAILABLE_PER_ZIP,
   MAX_ALL_ALC_PER_ZIP,
-  MAX_BEER_WINE_PER_ZIP
+  MAX_BEER_WINE_PER_ZIP,
 } from "./data-interface";
 
+// **FILTER MOCK DATA TO ONLY ELIGIBLE BOSTON ZIPCODES**
+const filteredMockData = (mockLicensesJson as BusinessLicense[]).filter(
+  (license) => isEligibleBostonZipCode(license.zipcode)
+);
+
 describe("Testing the data access interface", () => {
-  test("return number of all city-wide licenses (all zipcodes & all alcohol types)", () => {
-    const mockData = mockLicensesJson as BusinessLicense[];
-    const expected = MAX_LICENSES_AVAILABLE - 47;
-    expect(getNumOfLicenses(mockData)).toBe(expected);
+  describe("getAvailableLicensesByZipcode", () => {
+    test("returns the number of licenses by zip code for all alcohol types", () => {
+      const mockData = filteredMockData;
+
+      expect(getAvailableLicensesByZipcode(mockData, "02122")).toStrictEqual({
+        allAlcoholAvailable: MAX_ALL_ALC_PER_ZIP - 0,
+        beerWineAvailable: MAX_BEER_WINE_PER_ZIP - 2,
+        totalAvailable: MAX_AVAILABLE_PER_ZIP - 2,
+      });
+      expect(getAvailableLicensesByZipcode(mockData, "02130")).toStrictEqual({
+        allAlcoholAvailable: MAX_ALL_ALC_PER_ZIP - 2,
+        beerWineAvailable: MAX_BEER_WINE_PER_ZIP - 3,
+        totalAvailable: MAX_AVAILABLE_PER_ZIP - 5,
+      });
+    });
+    test("should handle empty data", () => {
+      expect(getAvailableLicensesByZipcode([], "02122")).toStrictEqual({
+        totalAvailable: MAX_AVAILABLE_PER_ZIP,
+        allAlcoholAvailable: MAX_ALL_ALC_PER_ZIP,
+        beerWineAvailable: MAX_BEER_WINE_PER_ZIP,
+      });
+    });
   });
 
-  test("returns the number of licenses by zip code for all alcohol types", () => {
-    const mockData = mockLicensesJson as BusinessLicense[];
+  describe("getZipcodesWithAvailableLicenses", () => {
+    const mockData = filteredMockData;
 
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02122" })).toBe(
-      MAX_AVAILABLE_PER_ZIP - 2
-    );
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02130" })).toBe(
-      MAX_AVAILABLE_PER_ZIP - 5
-    );
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02210" })).toBe(
-      MAX_AVAILABLE_PER_ZIP - 1
-    );
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02128" })).toBe(
-      MAX_AVAILABLE_PER_ZIP - 12
-    );
-    expect(getNumOfLicenses(mockData, { filterByZipcode: "02134" })).toBe(
-      MAX_AVAILABLE_PER_ZIP - 1
-    );
+    test("should filter and sort zipcodes correctly", () => {
+      const allResults = getZipcodesWithAvailableLicenses(mockData);
+      const allAlcoholResults = getZipcodesWithAvailableLicenses(
+        mockData,
+        "All Alcoholic Beverages"
+      );
+      const beerWineResults = getZipcodesWithAvailableLicenses(
+        mockData,
+        "Wines and Malt Beverages"
+      );
+
+      // Results should be sorted by zipcode
+      const allZipcodes = allResults.map((item) => item.zipcode);
+      expect(allZipcodes).toEqual([...allZipcodes].sort());
+
+      // Filtered results should only include zipcodes with availability for that type
+      allAlcoholResults.forEach((item) => {
+        expect(item.allAlcoholAvailable).toBeGreaterThan(0);
+      });
+
+      beerWineResults.forEach((item) => {
+        expect(item.beerWineAvailable).toBeGreaterThan(0);
+      });
+
+      // Should handle empty data
+      expect(getZipcodesWithAvailableLicenses([])).toEqual([]);
+    });
   });
 
-  test("returns number of licenses by alcohol type for all zip codes", () => {
-    const mockData = mockLicensesJson as BusinessLicense[];
+  describe("getNumLicenses", () => {
+    test("return number of all city-wide licenses (all zipcodes & all alcohol types)", () => {
+      const mockData = filteredMockData;
+      const expected = MAX_LICENSES_AVAILABLE - 32;
+      expect(getNumOfLicenses(mockData)).toBe(expected);
+    });
 
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByAlcoholType: "Wines and Malt Beverages",
-      })
-    ).toBe(MAX_BEER_WINE_LICENSES - 12);
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByAlcoholType: "All Alcoholic Beverages",
-      })
-    ).toBe(MAX_ALL_ALC_LICENSES - 35);
-  });
+    test("returns number of licenses by alcohol type for all zip codes", () => {
+      const mockData = mockLicensesJson as BusinessLicense[];
 
-  test("returns number of licenses by both zip code & alcohol type", () => {
-    const mockData = mockLicensesJson as BusinessLicense[];
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByZipcode: "02122",
-        filterByAlcoholType: "Wines and Malt Beverages",
-      })
-    ).toBe(MAX_BEER_WINE_PER_ZIP - 2);
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByZipcode: "02130",
-        filterByAlcoholType: "All Alcoholic Beverages",
-      })
-    ).toBe(MAX_ALL_ALC_PER_ZIP - 2);
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByZipcode: "02130",
-        filterByAlcoholType: "Wines and Malt Beverages",
-      })
-    ).toBe(MAX_BEER_WINE_PER_ZIP - 3);
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByZipcode: "02128",
-        filterByAlcoholType: "Wines and Malt Beverages",
-      })
-    ).toBe(MAX_BEER_WINE_PER_ZIP - 3);
-    expect(
-      getNumOfLicenses(mockData, {
-        filterByZipcode: "02128",
-        filterByAlcoholType: "All Alcoholic Beverages",
-      })
-    ).toBe(MAX_ALL_ALC_PER_ZIP - 9);
+      expect(
+        getNumOfLicenses(mockData, {
+          filterByAlcoholType: "Wines and Malt Beverages",
+        })
+      ).toBe(MAX_BEER_WINE_LICENSES - 12);
+      expect(
+        getNumOfLicenses(mockData, {
+          filterByAlcoholType: "All Alcoholic Beverages",
+        })
+      ).toBe(MAX_ALL_ALC_LICENSES - 35);
+    });
+
+    test("returns number of licenses by both zip code & alcohol type", () => {
+      const mockData = mockLicensesJson as BusinessLicense[];
+      expect(
+        getNumOfLicenses(mockData, {
+          filterByZipcode: "02122",
+          filterByAlcoholType: "Wines and Malt Beverages",
+        })
+      ).toBe(MAX_BEER_WINE_PER_ZIP - 2);
+      expect(
+        getNumOfLicenses(mockData, {
+          filterByZipcode: "02130",
+          filterByAlcoholType: "All Alcoholic Beverages",
+        })
+      ).toBe(MAX_ALL_ALC_PER_ZIP - 2);
+      expect(
+        getNumOfLicenses(mockData, {
+          filterByZipcode: "02130",
+          filterByAlcoholType: "Wines and Malt Beverages",
+        })
+      ).toBe(MAX_BEER_WINE_PER_ZIP - 3);
+    });
   });
 });

--- a/client/src/services/data-interface/data-interface.ts
+++ b/client/src/services/data-interface/data-interface.ts
@@ -60,7 +60,7 @@ type ValidationResult =
   | { valid: true; data: BusinessLicense }
   | { valid: false; errors: Record<string, string> };
 
-function isEligibleBostonZipCode(
+export function isEligibleBostonZipCode(
   zipcode: unknown
 ): zipcode is EligibleBostonZipcode {
   return (


### PR DESCRIPTION
Changes made:

- Now we only accept eligible Boston zip codes that were granted new restricted/non-transferable licenses. This helps us out any licenses granted not involved with the newly created licenses
- Rework interface to support the new data view chart layout