### PR TITLE
link 'resources' button text to correct translation key

### DIFF
--- a/client/src/data/locales/es-ES.json
+++ b/client/src/data/locales/es-ES.json
@@ -1,6 +1,5 @@
 {
   "header.maps": "MAPAS",
-  "ui.resources": "RECURSOS",
   "header.database": "BASE DE DATOS DE LICENCIAS",
   "header.resources": "RECURSOS DE LICENCIAS",
   "header.home": "INICIOS"


### PR DESCRIPTION
Hello, 
This PR fixes #198 by applying the changes made in #187 to another button, the "resources" button in the navigation panel. It also adds a Spanish translation for "resources", "recursos".

I am new to contributing to this project, please let me know if there's anything else I should add.

Dan
