### PR TITLE
Fixed the position of the footer on the not found page

### DIFF
--- a/client/src/components/pages/not-found/not-found.module.css
+++ b/client/src/components/pages/not-found/not-found.module.css
@@ -16,11 +16,10 @@
   .not-found-content {
     padding: 2rem;
     text-align: center;
-    background: rgba(
-      46,
-      46,
-      46,
-      0.8
+    background: color-mix(
+      in srgb,
+      var(--color-dark) 80%,
+      transparent
     ); /* Semi-transparent overlay for readability */
     border-radius: 8px;
     z-index: 1;

--- a/client/src/components/pages/not-found/not-found.module.css
+++ b/client/src/components/pages/not-found/not-found.module.css
@@ -1,11 +1,28 @@
 .not-found {
   width: 100%;
-  height: 223px;
+  min-height: calc(100vh - 200px); /* Account for header and footer space */
   flex-shrink: 0;
   background: var(--color-dark);
+  background-image: url("@/assets/images/beer-tap.png");
+  background-repeat: no-repeat;
+  background-position: center center;
+  background-size: cover;
   box-shadow: 0px 25px 20px 0px rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
 
   .not-found-content {
     padding: 2rem;
+    text-align: center;
+    background: rgba(
+      46,
+      46,
+      46,
+      0.8
+    ); /* Semi-transparent overlay for readability */
+    border-radius: 8px;
+    z-index: 1;
   }
 }

--- a/client/src/components/pages/not-found/not-found.tsx
+++ b/client/src/components/pages/not-found/not-found.tsx
@@ -1,6 +1,5 @@
 import notFoundStyles from "./not-found.module.css";
 import { FormattedMessage } from "react-intl";
-import beerTap from "@/assets/images/beer-tap.png";
 import BackToHome from "@/components/ui/back-to-home";
 import { useIntl } from "react-intl";
 
@@ -23,11 +22,6 @@ const NotFound = () => {
           <BackToHome />
         </div>
       </div>
-      <img
-        src={beerTap}
-        className={notFoundStyles.beerTap}
-        alt={intl.formatMessage({ id: "notFound.beerPourImageAlt" })}
-      />
     </main>
   );
 };

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -3,9 +3,20 @@ import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import NotFound from "@/components/pages/not-found/not-found";
 
+function NotFoundWithLayout() {
+  return (
+    <>
+      <HeadContent />
+      <Header />
+      <NotFound />
+      <Footer />
+    </>
+  );
+}
+
 export const Route = createRootRoute({
   component: RootComponent,
-  notFoundComponent: NotFound,
+  notFoundComponent: NotFoundWithLayout,
 });
 
 export function RootComponent() {


### PR DESCRIPTION
Fixes #204 
Problem
The footer was not rendering on the 404/Not Found page, creating an inconsistent user experience compared to other pages in the application. This occurred because the [notFoundComponent](vscode-file://vscode-app/c:/Users/nisha/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) in the root route bypassed the normal layout structure that includes the Header-Outlet-Footer flow.

✅ Solution
Fixed the footer rendering issue by creating a proper layout wrapper for the 404 page while preserving the existing functionality for all other pages.

✅ Footer now renders correctly on 404 pages
✅ All other pages remain unaffected
✅ Beer tap image appears as background covering the entire component
✅ Text content remains readable with semi-transparent overlay
✅ Responsive design maintained across different screen sizes

<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/0bb659ed-5c1f-46ac-b9ba-456b5a7257eb" />
