### PR TITLE
[#408] change map zoom, center, and zoom boundaries

### DIFF
--- a/client/src/components/pages/maps/BostonZipCodeMap.tsx
+++ b/client/src/components/pages/maps/BostonZipCodeMap.tsx
@@ -23,28 +23,53 @@ import mapStyles from "./BostonZipCodeMap.module.css";
 import "./mapStyleOverrides.css";
 import { ZipDetailsContent } from "./ZipDetailsContent";
 
+/* Map Styles */
+
+// Fill color if eligible zip code
+const activeFillColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-active-fill")
+  .trim();
+const activeBorderColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-active-border")
+  .trim();
+
+// Fill color if hovered
+const hoverFillColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-hover-fill")
+  .trim();
+const hoverBorderColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-hover-border")
+  .trim();
+
+// Fill color if selected
+const pressedFillColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-pressed-fill")
+  .trim();
+const pressedBorderColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-pressed-border")
+  .trim();
+
+// Fill color if not eligible zip code
+const inactiveFillColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-inactive-fill")
+  .trim();
+const inactiveBorderColor = getComputedStyle(document.documentElement)
+  .getPropertyValue("--color-map-inactive-border")
+  .trim();
+
+const borderWidth = 2;
+/* End Map Styles */
+
+/* Map Initialization */
 const initializeMap = (
   map: RefObject<Map | null>,
   mapContainer: RefObject<HTMLDivElement | null>
 ) => {
   const zoom = 11;
   const center = {
-    lng: -71.00884880372365,
-    lat: 42.33759424383746,
+    lng: -71.00957168341347,
+    lat: 42.29991918352738,
   };
-
-  const borderColor = getComputedStyle(document.documentElement)
-    .getPropertyValue("--color-map-border-red")
-    .trim();
-  const fillColor = getComputedStyle(document.documentElement)
-    .getPropertyValue("--color-map-red")
-    .trim();
-  const selectedColor = getComputedStyle(document.documentElement)
-    .getPropertyValue("--color-map-selected")
-    .trim();
-  const noDataColor = getComputedStyle(document.documentElement)
-    .getPropertyValue("--color-map-no-data")
-    .trim();
 
   map.current = new maplibregl.Map({
     container: mapContainer.current || "",
@@ -55,6 +80,9 @@ const initializeMap = (
       glyphs: "https://fonts.undpgeohub.org/fonts/{fontstack}/{range}.pbf",
     },
     center: [center.lng, center.lat],
+    dragRotate: false,
+    minZoom: 11,
+    maxZoom: 13.7,
     zoom: zoom,
     attributionControl: false
   });
@@ -66,6 +94,7 @@ const initializeMap = (
       type: "geojson",
       data: BostonZipCodeGeoJSON as GeoJSON.FeatureCollection,
     });
+    // Fill layer
     map.current.addLayer({
       id: "boston",
       type: "fill",
@@ -76,31 +105,43 @@ const initializeMap = (
           "case",
           // change color of selected zip code area if clicked
           ["boolean", ["feature-state", "clicked"], false],
-          selectedColor,
-          // determines zip code area color: if zip code is eligible, use fillColor, otherwise use noDataColor
-          ["in", ["get", "ZIP5"], ["literal", Array.from(eligibleBostonZipcodes)]],
-          fillColor,
-          noDataColor,
-        ],
-        "fill-opacity": [
-          "case",
-          ["boolean", ["feature-state", "clicked"], false],
-          1, // Full opacity when clicked
+          pressedFillColor,
           ["boolean", ["feature-state", "hover"], false],
-          1, // Full opacity when hovered
-          0.5, // Default opacity
+          hoverFillColor,
+          // determines zip code area color: if zip code is eligible, use activeFillColor, otherwise use inactiveFillColor
+          ["in", ["get", "ZIP5"], ["literal", Array.from(eligibleBostonZipcodes)]],
+          activeFillColor,
+          inactiveFillColor,
         ],
       },
     });
+    // Inactive outline layer - rendered first
     map.current.addLayer({
-      id: "boston-outline",
+      id: "boston-outline-inactive",
       type: "line",
       source: "boston",
-      layout: {},
       paint: {
-        "line-color": borderColor,
-        "line-width": 2,
+        "line-color": inactiveBorderColor,
+        "line-width": borderWidth,
       },
+      filter: ["!", ["in", ["get", "ZIP5"], ["literal", Array.from(eligibleBostonZipcodes)]]],
+    });
+    // Active outline layer - rendered second (on top)
+    map.current.addLayer({
+      id: "boston-outline-active",
+      type: "line",
+      source: "boston",
+      paint: {
+        "line-color": ["case",
+          ["boolean", ["feature-state", "clicked"], false],
+          pressedBorderColor,
+          ["boolean", ["feature-state", "hover"], false],
+          hoverBorderColor,
+          activeBorderColor,
+        ],
+        "line-width": borderWidth,
+      },
+      filter: ["in", ["get", "ZIP5"], ["literal", Array.from(eligibleBostonZipcodes)]],
     });
     map.current.addLayer({
       id: "symbols",
@@ -132,7 +173,7 @@ const initializeMouseActions = (
   map.current.on("click", "boston", (e) => {
     const feature = e.features?.[0];
     const zipCode = feature?.properties.ZIP5;
-
+    
     if (map.current && feature && eligibleBostonZipcodes.has(zipCode)) {
       setSelectedZip(zipCode);
       if (clickedFeatureId?.current) {
@@ -203,7 +244,7 @@ export const BostonZipCodeMap = () => {
 
   const uniqueZips = Array.from(eligibleBostonZipcodes);
 
-  const indexToZipCode : {[key: number]: string} = {};
+  const indexToZipCode: { [key: number]: string } = {};
   for (const [index, value] of uniqueZips.entries()) {
     indexToZipCode[index] = value;
   }
@@ -239,11 +280,11 @@ export const BostonZipCodeMap = () => {
             <div>
               {/* TODO(#369): pass in indexToZipCode for the tooltip data */}
               <DotPagination
-                currentPage={selectedZip ? uniqueZips.indexOf(selectedZip) : 0} 
-                totalPages={uniqueZips.length} 
+                currentPage={selectedZip ? uniqueZips.indexOf(selectedZip) : 0}
+                totalPages={uniqueZips.length}
                 onPageChange={(newZipIndex) => {
                   setSelectedZip(uniqueZips[newZipIndex]);
-                }} 
+                }}
               />
             </div>
           </div>

--- a/client/src/components/pages/maps/mapStyleOverrides.css
+++ b/client/src/components/pages/maps/mapStyleOverrides.css
@@ -8,10 +8,10 @@
 }
 
 .maplibregl-ctrl button.maplibregl-ctrl-zoom-in .maplibregl-ctrl-icon {
-  background-image: url('../../assets/icons/plus.svg');
+  background-image: url('../../../assets/icons/plus.svg');
   margin-bottom: 4px;
 }
 
 .maplibregl-ctrl button.maplibregl-ctrl-zoom-out .maplibregl-ctrl-icon {
-  background-image: url('../../assets/icons/minus.svg');
+  background-image: url('../../../assets/icons/minus.svg');
 }

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -111,10 +111,14 @@ colors will be named as they are used */
   --color-license-deferred-yellow: var(--color-yellow-3);
 
   /* Map */
-  --color-map-red: var(--color-red-1);
-  --color-map-border-red: var(--color-red-4);
-  --color-map-selected: var(--color-red-4);
-  --color-map-no-data: var(--color-gray-light-4);
+  --color-map-active-fill: #F38C8C;
+  --color-map-active-border: var(--color-red-1);
+  --color-map-hover-fill: #F5A3A3;
+  --color-map-hover-border: var(--color-red-2);
+  --color-map-pressed-fill: #EC4646;
+  --color-map-pressed-border: var(--color-red-4);
+  --color-map-inactive-fill: var(--color-gray-light-1);
+  --color-map-inactive-border: var(--color-gray-light-2);
 }
 
 /********************/


### PR DESCRIPTION
The following changes were made to the Map page per the design and discussions with Griffin:
- Changed colors of the active / inactive / selected zip codes
- Changed the default map zoom
- Added min and max zoom boundaries
- Fixed missing plus and minus icons on the zoom-in and zoom-out buttons

1920 x 840
<img width="1920" height="840" alt="image" src="https://github.com/user-attachments/assets/f60921ca-bccd-4a00-be6c-18c5c9461fd6" />
