### PR TITLE
Fix cell/column count mismatch after merge

### DIFF
--- a/client/src/components/pages/database/license-availability-table.tsx
+++ b/client/src/components/pages/database/license-availability-table.tsx
@@ -25,9 +25,12 @@ const getRowData = (
   totalAvailable: number,
   allAlcoholAvailable: number,
   beerWineAvailable: number,
-  recentApplicantsTotal: number,
-  recentApplicantsAllAlc: number,
-  recentApplicantsBeerWine: number,
+  totalApplicantsTotal: number,
+  totalApplicantsAllAlc: number,
+  totalApplicantsBeerWine: number,
+  openApplicationsTotal: number,
+  openApplicationsAllAlc: number,
+  openApplicationsBeerWine: number,
 ) => {
   let rowData;
   let subRowData;
@@ -36,7 +39,8 @@ const getRowData = (
     rowData = [
       zipcode,
       String(totalAvailable),
-      String(recentApplicantsTotal),
+      String(totalApplicantsTotal),
+      String(openApplicationsTotal),
       String(MAX_AVAILABLE_PER_ZIP - totalAvailable),
       String(MAX_AVAILABLE_PER_ZIP),
     ]
@@ -44,14 +48,16 @@ const getRowData = (
       [
         "All Alcohol Licenses",
         String(allAlcoholAvailable),
-        String(recentApplicantsAllAlc),
+        String(totalApplicantsAllAlc),
+        String(openApplicationsAllAlc),
         String(MAX_ALL_ALC_PER_ZIP - allAlcoholAvailable),
         String(MAX_ALL_ALC_PER_ZIP),
       ],
       [
         "Beer & Wine Licenses",
         String(beerWineAvailable),
-        String(recentApplicantsBeerWine),
+        String(totalApplicantsBeerWine),
+        String(openApplicationsBeerWine),
         String(MAX_BEER_WINE_PER_ZIP - beerWineAvailable),
         String(MAX_BEER_WINE_PER_ZIP),
       ],
@@ -60,7 +66,8 @@ const getRowData = (
     rowData = [
       zipcode,
       String(allAlcoholAvailable),
-      String(recentApplicantsAllAlc),
+      String(totalApplicantsAllAlc),
+      String(openApplicationsAllAlc),
       String(MAX_ALL_ALC_PER_ZIP - allAlcoholAvailable),
       String(MAX_ALL_ALC_PER_ZIP),
     ]
@@ -68,7 +75,8 @@ const getRowData = (
       [
         "All Alcohol Licenses",
         String(allAlcoholAvailable),
-        String(recentApplicantsAllAlc),
+        String(totalApplicantsAllAlc),
+        String(openApplicationsAllAlc),
         String(MAX_ALL_ALC_PER_ZIP - allAlcoholAvailable),
         String(MAX_ALL_ALC_PER_ZIP),
       ]
@@ -77,7 +85,8 @@ const getRowData = (
     rowData = [
       zipcode,
       String(beerWineAvailable),
-      String(recentApplicantsBeerWine),
+      String(totalApplicantsBeerWine),
+      String(openApplicationsBeerWine),
       String(MAX_BEER_WINE_PER_ZIP - beerWineAvailable),
       String(MAX_BEER_WINE_PER_ZIP),
     ]
@@ -85,7 +94,8 @@ const getRowData = (
       [
         "Beer & Wine Licenses",
         String(beerWineAvailable),
-        String(recentApplicantsBeerWine),
+        String(totalApplicantsBeerWine),
+        String(openApplicationsBeerWine),
         String(MAX_BEER_WINE_PER_ZIP - beerWineAvailable),
         String(MAX_BEER_WINE_PER_ZIP),
       ],
@@ -111,12 +121,16 @@ const formatData = (
     const { totalAvailable, allAlcoholAvailable, beerWineAvailable } =
       getAvailableLicensesByZipcode(grantedData, zipcode);
 
-    const deferred = data.filter((l) => l.zipcode === zipcode && l.status === "Deferred");
-    const recentApplicantsTotal = deferred.length;
-    const recentApplicantsAllAlc = deferred.filter((l) => l.alcohol_type === "All Alcoholic Beverages").length;
-    const recentApplicantsBeerWine = deferred.filter((l) => l.alcohol_type === "Wines and Malt Beverages").length;
+    const byZip = data.filter((l) => l.zipcode === zipcode);
+    const deferred = byZip.filter((l) => l.status === "Deferred");
+    const openApplicationsTotal = deferred.length;
+    const openApplicationsAllAlc = deferred.filter((l) => l.alcohol_type === "All Alcoholic Beverages").length;
+    const openApplicationsBeerWine = deferred.filter((l) => l.alcohol_type === "Wines and Malt Beverages").length;
+    const totalApplicantsTotal = byZip.length;
+    const totalApplicantsAllAlc = byZip.filter((l) => l.alcohol_type === "All Alcoholic Beverages").length;
+    const totalApplicantsBeerWine = byZip.filter((l) => l.alcohol_type === "Wines and Malt Beverages").length;
 
-    const {rowData, subRowData} = getRowData(zipcode, licenseType, totalAvailable, allAlcoholAvailable, beerWineAvailable, recentApplicantsTotal, recentApplicantsAllAlc, recentApplicantsBeerWine)
+    const {rowData, subRowData} = getRowData(zipcode, licenseType, totalAvailable, allAlcoholAvailable, beerWineAvailable, totalApplicantsTotal, totalApplicantsAllAlc, totalApplicantsBeerWine, openApplicationsTotal, openApplicationsAllAlc, openApplicationsBeerWine)
 
     const entry = {
       rowData: rowData,


### PR DESCRIPTION
Row data still had 5 cells after merge conflict resolution introduced 6 headers. Update getRowData and formatData to produce 6 cells per row with correct totalApplicants and openApplications values.