### PR TITLE
[#379] Deeplink from map details card to database page

### DIFF
--- a/client/src/components/pages/database/license-availability-table.module.css
+++ b/client/src/components/pages/database/license-availability-table.module.css
@@ -3,6 +3,8 @@
   padding: 2rem 4rem;
   overflow-x: scroll;
   border-radius: 4px;
+  /* Offset sticky site header when scrolling into view via deep link */
+  scroll-margin-top: 6rem;
 }
 
 .filters {
@@ -17,5 +19,6 @@
 @media (max-width: 768px) {
   .licenseAvailabilityTable {
     padding: 24px;
+    scroll-margin-top: 3.5rem;
   }
 }

--- a/client/src/components/pages/database/license-availability-table.tsx
+++ b/client/src/components/pages/database/license-availability-table.tsx
@@ -2,11 +2,13 @@ import styles from "./license-availability-table.module.css";
 import licenseData from "../../../data/licenses.json";
 import CustomTable from "@components/ui/table";
 import { useState, useEffect, useCallback } from "react";
+import { useSearch } from "@tanstack/react-router";
 import {
   validateBusinessLicense,
   getAvailableLicensesByZipcode,
   BusinessLicense,
   EligibleBostonZipcode,
+  isEligibleBostonZipCode,
 } from "@/services/data-interface/data-interface";
 import {
   MAX_ALL_ALC_PER_ZIP,
@@ -149,6 +151,11 @@ const licenseTypeOptions = [
 ];
 
 const LicenseAvailabilityTable = () => {
+  const { zip, section, expand } = useSearch({ from: "/database" });
+  const isDeepLinked = section === "license-availability";
+  const initialZip =
+    isDeepLinked && zip && isEligibleBostonZipCode(zip) ? zip : undefined;
+
   const [data, setData] = useState<BusinessLicense[]>([]);
   const [zipcodeList, setZipcodeList] = useState<Set<EligibleBostonZipcode>>(
     new Set()
@@ -170,6 +177,22 @@ const LicenseAvailabilityTable = () => {
 
     setData(tmp);
   }, []);
+
+  useEffect(() => {
+    if (!isDeepLinked) return;
+
+    const scrollToSection = () => {
+      document
+        .getElementById("license-availability")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    const frameId = requestAnimationFrame(() => {
+      requestAnimationFrame(scrollToSection);
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [isDeepLinked]);
 
   const availabilityHeaders = [
     "Zipcode",
@@ -205,12 +228,18 @@ const LicenseAvailabilityTable = () => {
   }
 
   return (
-    <section className={styles.licenseAvailabilityTable}>
+    <section
+      id="license-availability"
+      className={styles.licenseAvailabilityTable}
+    >
       <h4 className={styles.filterDescriptor}>
         <FormattedMessage id="database.availableLicenses.filterBy"/>
       </h4>
       <div className={`${styles.filters} gap-[16px]`}>
-        <ZipCodeFilter setZipcodeList={setZipcodeList} />
+        <ZipCodeFilter
+          setZipcodeList={setZipcodeList}
+          initialZip={initialZip}
+        />
         <FilterDropdown
           titleId="database.availableLicenses.licenseType"
           label="License Type dropdown selection"
@@ -223,6 +252,7 @@ const LicenseAvailabilityTable = () => {
         ariaLabel="Licenses by Zipcode"
         tableData={formattedData}
         headers={availabilityHeaders}
+        defaultSubRowsExpanded={isDeepLinked && expand}
       />
     </section>
   );

--- a/client/src/components/pages/database/recent-application-table.module.css
+++ b/client/src/components/pages/database/recent-application-table.module.css
@@ -2,6 +2,8 @@
   background-color: var(--color-background-light);
   padding: 2rem 4rem;
   overflow-x: scroll;
+  /* Offset sticky site header when scrolling into view via deep link */
+  scroll-margin-top: 6rem;
 }
 
 .heading {
@@ -40,5 +42,6 @@
 @media (max-width: 768px) {
   .licenseAvailabilityTable {
     padding: 24px;
+    scroll-margin-top: 3.5rem;
   }
 }

--- a/client/src/components/pages/database/recent-application-table.tsx
+++ b/client/src/components/pages/database/recent-application-table.tsx
@@ -11,8 +11,10 @@ import {
 } from "../../../services/data-interface/data-interface";
 import { RowWithSubRows } from "@components/ui/table";
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { useSearch } from "@tanstack/react-router";
 import licenseData from "../../../data/licenses.json";
 import { FormattedMessage } from "react-intl";
+import { isEligibleBostonZipCode } from "../../../services/data-interface/data-interface";
 import FilterDropdown from "@/components/ui/filter-dropdown";
 import ZipCodeFilter from "./zip-code-filter";
 import { Selection } from "react-aria-components";
@@ -85,6 +87,11 @@ const formatData = (
 };
 
 const RecentApplicationTable = () => {
+  const { zip, section, expand } = useSearch({ from: "/database" });
+  const isDeepLinked = section === "recent-applications";
+  const initialZip =
+    isDeepLinked && zip && isEligibleBostonZipCode(zip) ? zip : undefined;
+
   const [zipcodeList, setZipcodeList] = useState<Set<EligibleBostonZipcode>>(
     new Set()
   );
@@ -101,6 +108,23 @@ const RecentApplicationTable = () => {
 
     setData(tmp);
   }, []);
+
+  useEffect(() => {
+    if (!isDeepLinked) return;
+
+    const scrollToSection = () => {
+      document
+        .getElementById("recent-applications")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    };
+
+    // Defer until after layout from navigation and filter init
+    const frameId = requestAnimationFrame(() => {
+      requestAnimationFrame(scrollToSection);
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [isDeepLinked]);
   const recentApplicationHeaders = [
     "Zipcode/Business Name",
     "Doing Business As",
@@ -153,12 +177,18 @@ const RecentApplicationTable = () => {
   }
 
   return (
-    <section className={tableStyles.licenseAvailabilityTable}>
+    <section
+      id="recent-applications"
+      className={tableStyles.licenseAvailabilityTable}
+    >
         <h2>
           <FormattedMessage id="database.recentApplications.title" />
         </h2>
         <div className={`${tableStyles.filters} gap-[16px]`}>
-          <ZipCodeFilter setZipcodeList={setZipcodeList} />
+          <ZipCodeFilter
+            setZipcodeList={setZipcodeList}
+            initialZip={initialZip}
+          />
           <FilterDropdown
             titleId="database.recentApplications.applicationStatus"
             label="Application Status dropdown selection"
@@ -178,6 +208,7 @@ const RecentApplicationTable = () => {
         tableData={formattedData}
         headers={recentApplicationHeaders}
         cellFormatter={statusCellFormatter}
+        defaultSubRowsExpanded={isDeepLinked && expand}
       />
     </section>
   );

--- a/client/src/components/pages/database/zip-code-filter.tsx
+++ b/client/src/components/pages/database/zip-code-filter.tsx
@@ -9,16 +9,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface ZipCodeFilterProps {
   setZipcodeList: (zipCodes: Set<EligibleBostonZipcode>) => void
+  initialZip?: EligibleBostonZipcode
 }
 
 
-const ZipCodeFilter = ({ setZipcodeList }: ZipCodeFilterProps) => {
+const ZipCodeFilter = ({ setZipcodeList, initialZip }: ZipCodeFilterProps) => {
   const [selectedDropdownOptions, setSelectedDropdownOptions] =
     useState<Selection>(new Set());
-
-    useEffect(() => {
-      setZipcodeList(eligibleBostonZipcodes);
-    }, [setZipcodeList]);
 
   const dropdownZipOptions = useMemo(
     () =>
@@ -29,6 +26,18 @@ const ZipCodeFilter = ({ setZipcodeList }: ZipCodeFilterProps) => {
     []
   );
 
+  useEffect(() => {
+    if (initialZip) {
+      const option = dropdownZipOptions.find((o) => o.name === initialZip);
+      if (option) {
+        setSelectedDropdownOptions(new Set([option.id]));
+        setZipcodeList(new Set([initialZip]));
+      }
+    } else {
+      setZipcodeList(eligibleBostonZipcodes);
+    }
+  }, [initialZip, setZipcodeList, dropdownZipOptions]);
+
   const onZipSelectionChange = useCallback(
     (keys: Selection) => {
       setSelectedDropdownOptions(new Set(keys as Set<string>));
@@ -37,9 +46,8 @@ const ZipCodeFilter = ({ setZipcodeList }: ZipCodeFilterProps) => {
         (keys as Set<string>).has(option.id.toString())
       );
 
-      // Get zipcodes from selected options
       const zipcodes = selectedOptions.map(
-        (option) => option.name as EligibleBostonZipcode // assuming option.name is the zipcode
+        (option) => option.name as EligibleBostonZipcode
       );
 
       if (zipcodes.length) {

--- a/client/src/components/pages/maps/ZipDetailsContent.tsx
+++ b/client/src/components/pages/maps/ZipDetailsContent.tsx
@@ -9,6 +9,7 @@ import {
 import dataError from "../../../assets/icons/data-error.svg";
 import clipboards from "../../../assets/icons/clipboards-question-mark.svg";
 import { FormattedMessage, useIntl } from "react-intl";
+import { Link } from "@tanstack/react-router";
 import Tabs from "@/components/ui/tabs";
 
 type ZipDetailsProps = {
@@ -170,13 +171,13 @@ export const ZipDetailsContent = ({ licenses, zipCode }: ZipDetailsProps) => {
         <FormattedMessage id="map.zipDetails.zipCodeLicenseInfo" />
       </h3>
       <Tabs tabs={tabs} defaultTab="allLicenses" />
-      {/* TODO: Link to the appropriate section */}
-      <a
+      <Link
+        to="/database"
+        search={{ zip: zipCode, section: "license-availability", expand: true }}
         className="underline text-right m-2"
-        href="/boston-liquor-license-tracker/#/database"
       >
         <FormattedMessage id="map.zipDetails.detailedView" />
-      </a>
+      </Link>
 
       <h3 className="my-4">
         <FormattedMessage id="map.zipDetails.applicationsInZipCode" />
@@ -189,13 +190,13 @@ export const ZipDetailsContent = ({ licenses, zipCode }: ZipDetailsProps) => {
           {zipcodeLicenseData.applicants.length}
         </span>
       </div>
-      {/* TODO: Link to the appropriate section */}
-      <a
+      <Link
+        to="/database"
+        search={{ zip: zipCode, section: "recent-applications", expand: true }}
         className="underline text-right m-2"
-        href="/boston-liquor-license-tracker/#/database"
       >
         <FormattedMessage id="map.zipDetails.seeAllApplications" />
-      </a>
+      </Link>
     </div>
   );
 };

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -21,10 +21,11 @@ export interface CustomTableProps {
   headers: string[]
   tableData: RowWithSubRows[]
   cellFormatter?: (cell: string, rowIndex: number, cellIndex: number, isSubRow: boolean) => CellFormat
+  defaultSubRowsExpanded?: boolean
 }
 
-const StyledRow = ({rowData, subRowData, cellFormatter}: RowWithSubRows & { cellFormatter?: CustomTableProps['cellFormatter'] }) => {
-  const [subRowsVisible, setSubRowsVisible] = useState<boolean>(false)
+const StyledRow = ({rowData, subRowData, cellFormatter, defaultSubRowsExpanded}: RowWithSubRows & { cellFormatter?: CustomTableProps['cellFormatter']; defaultSubRowsExpanded?: boolean }) => {
+  const [subRowsVisible, setSubRowsVisible] = useState(defaultSubRowsExpanded ?? false)
 
   return (
     <>
@@ -81,7 +82,7 @@ const StyledSubRow = ({subRowData, cellFormatter}: SubRowProps & { cellFormatter
   )
 }
 
-const CustomTable = ({ariaLabel, tableData, headers, cellFormatter}: CustomTableProps) => {
+const CustomTable = ({ariaLabel, tableData, headers, cellFormatter, defaultSubRowsExpanded}: CustomTableProps) => {
   return (
     <Table aria-label={ariaLabel} className={styles.customTable}>
       <TableHeader className={styles.tableHeader}>
@@ -102,6 +103,7 @@ const CustomTable = ({ariaLabel, tableData, headers, cellFormatter}: CustomTable
             rowData={row.rowData} 
             subRowData={row.subRowData}
             cellFormatter={cellFormatter}
+            defaultSubRowsExpanded={defaultSubRowsExpanded}
           />
         ))}
       </TableBody>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -13,13 +13,22 @@ import "@styles/index.css";
 // Import the generated route tree
 import { routeTree } from "./routeTree.gen";
 import { K_LOCALE } from "./i18n/stored-locale";
+import { setupHashHistoryScrollRestoration } from "./setupHashHistoryScrollRestoration";
 
 // Use hash history for routing instead of browser history
 // github pages does not route arbitrary URLs to index.html
 const hashHistory = createHashHistory();
 
 // Create a new router instance
-const router = createRouter({ routeTree, history: hashHistory });
+const router = createRouter({
+  routeTree,
+  history: hashHistory,
+  scrollRestoration: true,
+  // Route paths live in the URL hash; do not treat them as in-page anchor ids.
+  defaultHashScrollIntoView: false,
+});
+
+setupHashHistoryScrollRestoration(router);
 
 // Set initial HTML lang attribute
 const locale = localStorage.getItem(K_LOCALE) || "en-US";

--- a/client/src/routes/database.tsx
+++ b/client/src/routes/database.tsx
@@ -1,6 +1,30 @@
 import { createFileRoute } from "@tanstack/react-router";
 import Database from "@/components/pages/database/database";
 
+export const DATABASE_SECTIONS = [
+  "license-availability",
+  "recent-applications",
+] as const;
+
+export type DatabaseSection = (typeof DATABASE_SECTIONS)[number];
+
+export type DatabaseSearch = {
+  zip?: string;
+  section?: DatabaseSection;
+  expand?: boolean;
+};
+
+function parseSection(value: unknown): DatabaseSection | undefined {
+  return DATABASE_SECTIONS.includes(value as DatabaseSection)
+    ? (value as DatabaseSection)
+    : undefined;
+}
+
 export const Route = createFileRoute("/database")({
+  validateSearch: (search: Record<string, unknown>): DatabaseSearch => ({
+    zip: typeof search.zip === "string" ? search.zip : undefined,
+    section: parseSection(search.section),
+    expand: search.expand === true || search.expand === "true",
+  }),
   component: Database,
 });

--- a/client/src/routes/database.tsx
+++ b/client/src/routes/database.tsx
@@ -1,14 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import Database from "@/components/pages/database/database";
 
-export const DATABASE_SECTIONS = [
+const DATABASE_SECTIONS = [
   "license-availability",
   "recent-applications",
 ] as const;
 
-export type DatabaseSection = (typeof DATABASE_SECTIONS)[number];
+type DatabaseSection = (typeof DATABASE_SECTIONS)[number];
 
-export type DatabaseSearch = {
+type DatabaseSearch = {
   zip?: string;
   section?: DatabaseSection;
   expand?: boolean;

--- a/client/src/setupHashHistoryScrollRestoration.ts
+++ b/client/src/setupHashHistoryScrollRestoration.ts
@@ -1,0 +1,29 @@
+import type { AnyRouter } from "@tanstack/router-core";
+import {
+  defaultGetScrollRestorationKey,
+  scrollRestorationCache,
+} from "@tanstack/router-core";
+
+/**
+ * TanStack Router's built-in restoreScroll treats `window.location.hash` as an
+ * element id. With hash-based routing (`#/maps`), that branch always runs and
+ * returns without scrolling to the top. This fills the gap: scroll to top when
+ * there is no saved window position for the destination.
+ */
+export function setupHashHistoryScrollRestoration(router: AnyRouter) {
+  router.subscribe("onRendered", (event) => {
+    if (!router.resetNextScroll) {
+      router.resetNextScroll = true;
+      return;
+    }
+
+    const getKey =
+      router.options.getScrollRestorationKey ?? defaultGetScrollRestorationKey;
+    const key = getKey(event.toLocation);
+    const windowEntry = scrollRestorationCache?.state?.[key]?.window;
+
+    if (!windowEntry) {
+      window.scrollTo(0, 0);
+    }
+  });
+}


### PR DESCRIPTION
This PR fixes the "Detailed View" and "See All Applications" links on the Map page's detail cards. They now deeplink to their respective tables with the subrows opened so that the details are visible.


https://github.com/user-attachments/assets/d218a223-1368-4f39-83c0-9ef91ecb9209

