### PR TITLE
Updated Database Available License Table Headers

### DIFF
--- a/client/src/data/locales/en-US.json
+++ b/client/src/data/locales/en-US.json
@@ -29,14 +29,16 @@
   "database.availableLicenses.description": "In 2024 a new law increased access to liquor licenses in several parts of Boston. Through this law the city will be issuing 5 new on premise liquor licenses to 13 of Boston’s Zip Codes each year for the next 3 years.",
   "database.availableLicenses.title": "2024 Cohort Licenses",
   "database.availableLicenses.filterBy": "Filter By",
-  "database.availableLicenses.zipCode": "Zip Code",
   "database.availableLicenses.licenseType": "License Type",
-  "database.availableLicenses.licensesAvailable": "Licenses Available:",
-  "database.availableLicenses.recentApplicants": "Recent Applicants:",
-  "database.availableLicenses.licensesGranted": "Licenses Granted:",
-  "database.availableLicenses.totalLicenses": "Total Licenses:",
-  "database.availableLicenses.allAlcohol": "All Alcohol Licenses:",
-  "database.availableLicenses.wineBeerLicenses": "Wine & Beer Licenses:",
+  "database.availableLicenses.allAlcohol": "All Alcohol Licenses",
+  "database.availableLicenses.wineBeerLicenses": "Wine & Malt Licenses",
+  "database.availableLicenses.zipCode": "Zip Code,"
+  "database.availableLicenses.totalLicenses": "Total Licenses",
+  "database.availableLicenses.licensesAvailable": "Licenses Available",
+  "database.availableLicenses.totalApplicants": "Total Applicants",
+  "database.availableLicenses.openApplicants": "Open Applicants",
+  "database.availableLicenses.licensesGranted": "Licenses Granted",
+
 
   "database.header.description": "Browse through available licenses in each of Boston's ZIP codes, view important information regarding each license type and recent license applications. As well as important dates for license applications.",
   "database.header.nextMeeting": "The next Licensing Boarding meeting is: <strong>{nextMeetingDate, date, long}</strong>",

--- a/client/src/data/locales/en-US.json
+++ b/client/src/data/locales/en-US.json
@@ -32,7 +32,7 @@
   "database.availableLicenses.licenseType": "License Type",
   "database.availableLicenses.allAlcohol": "All Alcohol Licenses",
   "database.availableLicenses.wineBeerLicenses": "Wine & Malt Licenses",
-  "database.availableLicenses.zipCode": "Zip Code,"
+  "database.availableLicenses.zipCode": "Zip Code",
   "database.availableLicenses.totalLicenses": "Total Licenses",
   "database.availableLicenses.licensesAvailable": "Licenses Available",
   "database.availableLicenses.totalApplicants": "Total Applicants",


### PR DESCRIPTION
With the change to the Available License table and the data shown in the table. The master doc and this locale file have drifted out of alignment with the copy currently used on the production site. 

This pull request fixes the locale document and is pushed alongside an update to the local master doc located here:

[Master Translation Document](https://docs.google.com/document/d/1Q7XeRzKGyoxlMTgHIlnJMYFBhyfd1AZcpQR9HHeSZ-s/edit?usp=sharing)

**Notes**
- This only changed the English locale pages and will need to have Spanish and Chinese pages updated along side it
- The production page for the database page and its tables still uses hard coded copy and will need an implemented fix moving forward.
- This fix will be introduced as a task shortly after this pull request is pushed